### PR TITLE
Remove provider block configuration

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,0 @@
-provider "aws" {
-  region = var.aws_region
-}
-
-provider "github" {
-  owner = var.github_org
-}


### PR DESCRIPTION
Terraform modules shouldn't contain provider configuration since it breaks some things down the line.

More info:
https://www.terraform.io/docs/language/modules/develop/providers.html